### PR TITLE
catch corrupt tarballs. move to corrupt queue

### DIFF
--- a/ingestor/l8_process_scene.py
+++ b/ingestor/l8_process_scene.py
@@ -55,7 +55,10 @@ def process(source, scene_root, verbose=False, clean=False, list_file=None,
     local_tarfile = puller.pull(source, scene_root, scene_dict,
                                 verbose=verbose)
 
-    local_dir = splitter.split(scene_root, local_tarfile, verbose=verbose)
+    try:
+        local_dir = splitter.split(scene_root, local_tarfile, verbose=verbose)
+    except:
+        puller_s3queue.move_to_corrupt_queue(scene_root)
 
     scene_info.add_mtl_info(scene_dict, scene_root, local_dir)
     

--- a/ingestor/l8_process_scene.py
+++ b/ingestor/l8_process_scene.py
@@ -58,7 +58,8 @@ def process(source, scene_root, verbose=False, clean=False, list_file=None,
     try:
         local_dir = splitter.split(scene_root, local_tarfile, verbose=verbose)
     except:
-        puller_s3queue.move_to_corrupt_queue(scene_root)
+        if source is 's3queue':
+            puller_s3queue.move_to_corrupt_queue(scene_root)
 
     scene_info.add_mtl_info(scene_dict, scene_root, local_dir)
     

--- a/ingestor/l8_process_scene.py
+++ b/ingestor/l8_process_scene.py
@@ -60,6 +60,7 @@ def process(source, scene_root, verbose=False, clean=False, list_file=None,
     except:
         if source is 's3queue':
             puller_s3queue.move_to_corrupt_queue(scene_root)
+            return
 
     scene_info.add_mtl_info(scene_dict, scene_root, local_dir)
     

--- a/ingestor/puller_usgs.py
+++ b/ingestor/puller_usgs.py
@@ -32,10 +32,6 @@ def retry_get(url, retries=4, **kwargs):
     for _ in xrange(retries + 1):
         rv = requests.get(url, **kwargs)
         if rv is None or rv.status_code != 503:
-            
-            # TODO: Check that the tarball is not corrupt
-            
-            
             return rv
 
         print 'GET %s reports code %s, retry in %s' % (

--- a/ingestor/puller_usgs.py
+++ b/ingestor/puller_usgs.py
@@ -32,6 +32,10 @@ def retry_get(url, retries=4, **kwargs):
     for _ in xrange(retries + 1):
         rv = requests.get(url, **kwargs)
         if rv is None or rv.status_code != 503:
+            
+            # TODO: Check that the tarball is not corrupt
+            
+            
             return rv
 
         print 'GET %s reports code %s, retry in %s' % (


### PR DESCRIPTION
@warmerdam These changes capture arbitrary errors from `splitter.split` (e.g. corrupt tarballs). In these cases, scenes are moved to the `tarq_corrupt` directory for later attempts.
