### PR TITLE
Support Landsat collections

### DIFF
--- a/ingestor/l8_lib.py
+++ b/ingestor/l8_lib.py
@@ -1,15 +1,33 @@
+
 import hashlib
 import md5
 
-def parse_scene(scene_root):
-    """returns (sensor, path, row)"""
 
-    # Root looks like 'LC80010082013237LGN00'
+def parse_scene(scene_root):
+    """
+    Returns (sensor, path, row) based on either an entity id (e.g. LC80410342017032LGN01)
+    or a product id (e.g. LC08_L1TP_041034_20170201_20170218_01_T1).
+    """
 
     assert scene_root[0] == 'L'
-    assert len(scene_root) == 21
 
-    return (scene_root[0:3], scene_root[3:6], scene_root[6:9])
+    if (len(scene_root) == 21):
+        sensor = scene_root[0:3]
+        path = scene_root[3:6]
+        row = scene_root[6:9]
+    elif (len(scene_root) == 40):
+        sensor = scene_root[0:4]
+        path = scene_root[10:13]
+        row = scene_root[13:16]
+    else:
+        raise Exception("This does not appear to be a Landsat 8 identifier.")
+
+    return (sensor, path, row)
+
+
+def is_entity_id(scene_root):
+    return True if len(scene_root) == 21 else False
+
 
 def get_file_md5sum(filename):
     """Compute MD5Sum of a file.
@@ -24,4 +42,3 @@ def get_file_md5sum(filename):
     for chunk in iter(lambda: fd.read(8192), b''):
         md5.update(chunk)
     return md5.hexdigest()
-

--- a/ingestor/pusher.py
+++ b/ingestor/pusher.py
@@ -12,6 +12,7 @@ from boto.s3.key import Key
 
 import l8_aws_config
 import l8_lib
+from l8_lib import is_entity_id
 
 s3_connection = None
 s3_bucket = None
@@ -90,9 +91,17 @@ def move_file(src_s3_path, dst_s3_path, overwrite=False):
                            src_key_name = src_s3_path)
     unlink_file(src_s3_path)
 
+
 def _scene_root_to_path(scene_root):
     sensor, path, row = l8_lib.parse_scene(scene_root)
-    return 'L8/%s/%s/%s' % (path, row, scene_root)
+
+    if is_entity_id(scene_root):
+        path = 'L8/%s/%s/%s' % (path, row, scene_root)
+    else:
+        path = 'c1/L8/%s/%s/%s' % (path, row, scene_root)
+
+    return path
+
 
 def scene_url(scene_root):
     return l8_aws_config.BUCKET_URL + '/' + _scene_root_to_path(scene_root)
@@ -208,6 +217,15 @@ def get_past_list():
         os.system('gzip -f -d scene_list.gz')
 
     return 'scene_list'
+
+
+def get_past_collection_list():
+    key = _get_key('c1/L8/scene_list.gz')
+    key.get_contents_to_filename('scene_list.gz')
+    os.system('gzip -f -d scene_list.gz')
+
+    return 'scene_list'
+
 
 def list(prefix='', limit=None):
     bucket = _get_bucket()


### PR DESCRIPTION
USGS is deprecating pre-collection archives, and encouraging Landsat users to adopt the new collections data model. This PR allows the new product identifier used in collections to be used during ingestion. If a collections identifier is given, then the scene will be uploaded to:

```
s3://landsat-pds/c1/L8/[path]/[row]/[product id/
```

All collection scenes will be appended to a new `scene_list`, located at:

```
s3://landsat-pds/c1/L8/scene_list.gz
```