### PR TITLE
Add option to leave tarfile in the queue after processing

### DIFF
--- a/ingestor/l8_process_scene.py
+++ b/ingestor/l8_process_scene.py
@@ -95,6 +95,8 @@ def get_parser():
                          help='Report details on progress.')
     aparser.add_argument('-l', '--list-file', 
                          help='List .csv file to append processing record to.')
+    aparser.add_argument('--no-delete-queue', action='store_true',
+                         help='Do not remove the scene from the s3 queue')
     aparser.add_argument('scene',
                          help='Scene name, ie. LC82301202013305LGN00')
     return aparser
@@ -107,7 +109,7 @@ def main(rawargs):
                          list_file = args.list_file,
                          overwrite = args.overwrite)
 
-    if args.source == 's3queue':
+    if args.source == 's3queue' and not args.no_delete_queue:
         puller_s3queue.clean_queued_tarfile(args.scene, verbose=args.verbose)
 
     if args.verbose:


### PR DESCRIPTION
In order to allow more flexibility in processing, it would be useful to have an option to leave processed tarfiles in the s3 queue after successful processing with `l8_process_scene.py`.  

This PR adds a `--no-delete-queue` option that, if specified, leaves processed scenes in the queue.